### PR TITLE
Add `delay` for message

### DIFF
--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\Redis\Message;
+
+use Yiisoft\Queue\Message\MessageInterface;
+
+final class Message implements MessageInterface
+{
+    public function __construct(
+        private string $handlerName,
+        private mixed  $data,
+        private array  $metadata,
+        private int    $delay = 0 //delay in seconds
+    )
+    {
+        if ($this->delay > 0) {
+            $this->metadata['delay'] = $delay;
+        }
+    }
+
+    public function withDelay(int $delay): self
+    {
+        $message = clone $this;
+        $message->metadata['delay'] = $delay;
+        return $message;
+    }
+
+    public function getHandlerName(): string
+    {
+        return $this->handlerName;
+    }
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/tests/Integration/QueueProviderTest.php
+++ b/tests/Integration/QueueProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Redis\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Queue\Redis\Message\Message;
 use Yiisoft\Queue\Redis\QueueProvider;
 use Yiisoft\Queue\Redis\QueueProviderInterface;
 
@@ -19,7 +20,7 @@ class QueueProviderTest extends TestCase
         $this->assertGreaterThan(0, $id);
     }
 
-    public function test__construct()
+    public function test__construct(): QueueProvider
     {
         $redis = new \Redis();
         $connected = $redis->connect('redis');
@@ -27,5 +28,20 @@ class QueueProviderTest extends TestCase
         $provider = new QueueProvider($redis, 'test');
         $this->assertInstanceOf(QueueProviderInterface::class, $provider);
         return $provider;
+    }
+
+    /**
+     * @depends test__construct
+     */
+    public function testDelay(QueueProvider $provider): void
+    {
+        $message = new Message('test', ['key' => 'value'], [], 2);
+        $id = $provider->pushMessage(json_encode($message->getData(), JSON_THROW_ON_ERROR), $message->getMetadata());
+        $this->assertGreaterThan(0, $id);
+        $reserv = $provider->reserve($id);
+        $this->assertNull($reserv);
+        sleep(3);
+        $reserv = $provider->reserve($id);
+        $this->assertNotNull($reserv);
     }
 }

--- a/tests/Message/MessageTest.php
+++ b/tests/Message/MessageTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\Redis\Tests\Message;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Queue\Redis\Message\Message;
+
+class MessageTest extends TestCase
+{
+    public function testGetHandlerName(): void
+    {
+        $message = new Message('handler', 'data', []);
+        $this->assertEquals('handler', $message->getHandlerName());
+    }
+
+    public function testGetData(): void
+    {
+        $message = new Message('handler', 'data', []);
+        $this->assertEquals('data', $message->getData());
+    }
+
+    public function testGetMetadata(): void
+    {
+        $metadata = ['key' => 'value'];
+        $message = new Message('handler', 'data', $metadata);
+        $this->assertEquals($metadata, $message->getMetadata());
+
+        $message = new Message('handler', 'data', $metadata, 2);
+        $metadata['delay'] = 2;
+        $this->assertEquals($metadata, $message->getMetadata());
+    }
+
+    public function testWithDelay(): void
+    {
+        $message = new Message('handler', 'data', []);
+        $delayedMessage = $message->withDelay(5);
+
+        $this->assertNotSame($message, $delayedMessage);
+        $this->assertEquals(5, $delayedMessage->getMetadata()['delay']);
+    }
+}

--- a/tests/Unit/Message/MessageTest.php
+++ b/tests/Unit/Message/MessageTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Yiisoft\Queue\Redis\Tests\Message;
+namespace Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Redis\Message\Message;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

How Use

Create `Message`
```
use Yiisoft\Queue\Redis\Message\Message;
$message = new Message('test', ['key' => 'value'], [], 2); //delay 2 second
```
or
```
use Yiisoft\Queue\Redis\Message\Message;
$message = new Message('test', ['key' => 'value'], []);
$message = $message->withDelay(2);
```

or
```
$message = new \Yiisoft\Queue\Message\Message('test', ['key' => 'value'], ['delay' => 2]);
```
