### PR TITLE
Add `hasStatusSupport()` to `Adapter`

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -60,6 +60,11 @@ final class Adapter implements AdapterInterface
         return MessageStatus::DONE;
     }
 
+    public function hasStatusSupport(): bool
+    {
+        return true;
+    }
+
     public function push(MessageInterface $message): MessageInterface
     {
         $payload = $this->serializer->serialize($message);

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -53,6 +53,17 @@ class QueueTest extends TestCase
         $this->assertTrue($notUseHandler);
     }
 
+    public function testHasStatusSupport(): void
+    {
+        $adapter = new Adapter(
+            $this->createMock(QueueProviderInterface::class),
+            $this->createMock(MessageSerializerInterface::class),
+            $this->createMock(LoopInterface::class)
+        );
+
+        $this->assertTrue($adapter->hasStatusSupport());
+    }
+
     public function testGetChannel(): void
     {
         $expectedChannelName = 'test-channel';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ✔️
| Tests pass?   | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Implements `AdapterInterface::hasStatusSupport()` added in yiisoft/queue#299. The Redis adapter tracks message status, so it returns `true`.

Companion PR for yiisoft/queue#299 (issue yiisoft/queue#272); needs that one merged and released first.
